### PR TITLE
Fixed bug with eyes

### DIFF
--- a/scripts/control.js
+++ b/scripts/control.js
@@ -115,7 +115,7 @@ function neckValueChanged(target) {
 }
 
 function lookatChanged(target) {
-  robot.setEyes("currentEyes", target.id);
+  robot.setEyes(target.id, "currentEyes");
 }
 
 function bellyScreenChanged(target) {


### PR DESCRIPTION
First parameter in robot.setEyes() is the value that gets send to the database, which is why currentEyes gets set to "currentEyes" in the database instead of "up", "down", etc.